### PR TITLE
Implement TranslateBinding

### DIFF
--- a/LocalizationResourceManager.Maui.Sample/MainPage.xaml
+++ b/LocalizationResourceManager.Maui.Sample/MainPage.xaml
@@ -35,7 +35,7 @@
                 Clicked="OnCounterClicked"
                 HorizontalOptions="Center"
                 SemanticProperties.Hint="{localization:Translate CounterBtnHint}"
-                Text="{Binding CounterBtnText.Localized}" />
+                Text="{localization:TranslateBinding Count, TranslateFormat=ClickedManyTimes, TranslateOne=ClickedOneTime, TranslateZero=ClickMe}" />
 
             <Label
                 FontSize="Small"

--- a/LocalizationResourceManager.Maui.Sample/MainPage.xaml.cs
+++ b/LocalizationResourceManager.Maui.Sample/MainPage.xaml.cs
@@ -8,8 +8,9 @@ namespace LocalizationResourceManager.Maui.Sample
         private int count = 0;
         private readonly ILocalizationResourceManager resourceManager;
 
+        public int Count => count;
+
         public LocalizedString HelloWorld { get; }
-        public LocalizedString CounterBtnText { get; }
         public LocalizedString CurrentCulture { get; }
 
         public MainPage(ILocalizationResourceManager resourceManager)
@@ -18,23 +19,15 @@ namespace LocalizationResourceManager.Maui.Sample
             this.resourceManager = resourceManager;
 
             HelloWorld = new(() => $"{resourceManager["Hello"]}, {resourceManager["World"]}!");
-            CounterBtnText = new(() => GetCounterBtnText());
             CurrentCulture = new(() => resourceManager.CurrentCulture.NativeName);
 
             BindingContext = this;
         }
 
-        private string GetCounterBtnText()
-        {
-            if (count == 0) return resourceManager["ClickMe"];
-            if (count == 1) return resourceManager["ClickedOneTime", count];
-            return resourceManager["ClickedManyTimes", count];
-        }
-
         private void OnCounterClicked(object sender, EventArgs e)
         {
             count++;
-            OnPropertyChanged(nameof(CounterBtnText));
+            OnPropertyChanged(nameof(Count));
         }
 
         private void OnToggleLanguage(object sender, EventArgs e)

--- a/LocalizationResourceManager.Maui/TranslateBindingExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateBindingExtension.cs
@@ -1,0 +1,120 @@
+﻿using System.Collections.ObjectModel;
+using System.Globalization;
+
+namespace LocalizationResourceManager.Maui;
+
+[ContentProperty(nameof(Path))]
+public class TranslateBindingExtension : IMarkupExtension<BindingBase>, IMultiValueConverter
+{
+    /// <inheritdoc/>
+    public string Path { get; set; } = ".";
+
+    /// <inheritdoc/>
+    public BindingMode Mode { get; set; } = BindingMode.OneWay;
+
+    /// <inheritdoc/>
+    public string StringFormat { get; set; } = "{0}";
+
+    /// <inheritdoc/>
+    public IValueConverter Converter { get; set; } = null;
+
+    /// <inheritdoc/>
+    public object ConverterParameter { get; set; } = null;
+
+    /// <inheritdoc/>
+    public object Source { get; set; } = null;
+
+    /// <inheritdoc/>
+    public bool TranslateValue { get; set; } = false;
+
+    /// <inheritdoc/>
+    public string TranslateFormat { get; set; }
+
+    /// <inheritdoc/>
+    public string TranslateOne { get; set; }
+
+    /// <inheritdoc/>
+    public string TranslateZero { get; set; }
+
+    /// <inheritdoc/>
+    public object ProvideValue(IServiceProvider serviceProvider)
+    {
+        return (this as IMarkupExtension<BindingBase>).ProvideValue(serviceProvider);
+    }
+
+    BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
+    {
+        return new MultiBinding()
+        {
+            StringFormat = StringFormat,
+            Converter = this,
+            Mode = Mode,
+            Bindings = new Collection<BindingBase>
+            {
+                new Binding(Path, Mode, Converter, ConverterParameter, null, Source),
+                new Binding(nameof(LocalizationResourceManager.CurrentCulture), BindingMode.OneWay, null, null, null, LocalizationResourceManager.Current)
+            }
+        };
+    }
+
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length == 0 || values[0] == null)
+        {
+            return "";
+        }
+
+        if (!string.IsNullOrEmpty(TranslateZero) && IsZero(values[0]))
+        {
+            return LocalizationResourceManager.Current[TranslateZero, values];
+        }
+
+        if (!string.IsNullOrEmpty(TranslateOne) && IsOne(values[0]))
+        {
+            return LocalizationResourceManager.Current[TranslateOne, values];
+        }
+
+        if (!string.IsNullOrEmpty(TranslateFormat))
+        {
+            return LocalizationResourceManager.Current[TranslateFormat, values];
+        }
+
+        if (TranslateValue)
+        {
+            return LocalizationResourceManager.Current[values[0].ToString()];
+        }
+
+        return values[0];
+    }
+
+    static bool IsZero(object value)
+    {
+        if (value == null)
+        {
+            return false;
+        }
+        if (value.GetType() == typeof(int) && (int)value == 0)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    static bool IsOne(object value)
+    {
+        if (value == null)
+        {
+            return false;
+        }
+        if (value.GetType() == typeof(int) && (int)value == 1)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Implement `TranslateBinding` markup extension which is similar to `Binding` but with these enhancements:

`Path` - Same as `Binding.Path`
`Converter` - Same as `Binding.Converter`
`ConverterParameter` - Same as `Binding.ConverterParameter`
`StringFormat` - Same as `Binding.StringFormat`
`Source` - Same as `Binding.Source`
`TranslateFormat` - Use string resource to lookup the string format
`TranslateOne` - Use string resource to lookup the string format when bound value is one (1)
`TranslateZero` - Use string resource to lookup the string format when bound value is zero (0)
`TranslateValue` - Translate the bound value