### PR TITLE
Translate with bindable properties. SetTranslate extension method.

### DIFF
--- a/LocalizationResourceManager.Maui.Sample/MainPage.xaml
+++ b/LocalizationResourceManager.Maui.Sample/MainPage.xaml
@@ -12,6 +12,17 @@
             Spacing="15"
             VerticalOptions="Center">
 
+            <VerticalStackLayout BindingContext="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}}">
+                <CollectionView ItemsSource="{Binding MyStrings}">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <Label Text="{localization:Translate {Binding Localization}}" />
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+                <Picker  ItemsSource="{Binding MyStrings}" />
+            </VerticalStackLayout>
+
             <Image
                 HeightRequest="200"
                 HorizontalOptions="Center"

--- a/LocalizationResourceManager.Maui.Sample/MainPage.xaml
+++ b/LocalizationResourceManager.Maui.Sample/MainPage.xaml
@@ -3,7 +3,8 @@
     x:Class="LocalizationResourceManager.Maui.Sample.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:localization="clr-namespace:LocalizationResourceManager.Maui;assembly=LocalizationResourceManager.Maui">
+    xmlns:localization="clr-namespace:LocalizationResourceManager.Maui;assembly=LocalizationResourceManager.Maui"
+    Title="{localization:Translate Home}">
 
     <ScrollView>
         <VerticalStackLayout
@@ -35,7 +36,7 @@
                 Clicked="OnCounterClicked"
                 HorizontalOptions="Center"
                 SemanticProperties.Hint="{localization:Translate CounterBtnHint}"
-                Text="{localization:TranslateBinding Count, TranslateFormat=ClickedManyTimes, TranslateOne=ClickedOneTime, TranslateZero=ClickMe}" />
+                Text="{localization:Translate ClickMe}" />
 
             <Label
                 FontSize="Small"

--- a/LocalizationResourceManager.Maui.Sample/MainPage.xaml
+++ b/LocalizationResourceManager.Maui.Sample/MainPage.xaml
@@ -12,17 +12,6 @@
             Spacing="15"
             VerticalOptions="Center">
 
-            <VerticalStackLayout BindingContext="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}}">
-                <CollectionView ItemsSource="{Binding MyStrings}">
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate>
-                            <Label Text="{localization:Translate {Binding Localization}}" />
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                </CollectionView>
-                <Picker  ItemsSource="{Binding MyStrings}" />
-            </VerticalStackLayout>
-
             <Image
                 HeightRequest="200"
                 HorizontalOptions="Center"

--- a/LocalizationResourceManager.Maui.Sample/MainPage.xaml.cs
+++ b/LocalizationResourceManager.Maui.Sample/MainPage.xaml.cs
@@ -3,15 +3,10 @@ using System.Globalization;
 
 namespace LocalizationResourceManager.Maui.Sample
 {
-    public record class Option
-    {
-        public string Localization { get; set; } = string.Empty;
-    }
     public partial class MainPage : ContentPage
     {
         private int count = 0;
         private readonly ILocalizationResourceManager resourceManager;
-        public List<Option> MyStrings { get; } = new () { new Option { Localization = "ClickMe" }, new Option { Localization = "ClickedOneTime" }, new Option { Localization = "ClickedManyTimes" } };
 
         public LocalizedString HelloWorld { get; }
         public LocalizedString CurrentCulture { get; }

--- a/LocalizationResourceManager.Maui.Sample/MainPage.xaml.cs
+++ b/LocalizationResourceManager.Maui.Sample/MainPage.xaml.cs
@@ -8,16 +8,6 @@ namespace LocalizationResourceManager.Maui.Sample
         private int count = 0;
         private readonly ILocalizationResourceManager resourceManager;
 
-        public int Count
-        {
-            get => count;
-            set
-            {
-                count = value;
-                OnPropertyChanged(nameof(Count));
-            }
-        }
-
         public LocalizedString HelloWorld { get; }
         public LocalizedString CurrentCulture { get; }
 
@@ -32,7 +22,17 @@ namespace LocalizationResourceManager.Maui.Sample
             BindingContext = this;
         }
 
-        private void OnCounterClicked(object sender, EventArgs e) => Count++;
+        private void OnCounterClicked(object sender, EventArgs e)
+        {
+            count++;
+
+            if (count == 1)
+                CounterBtn.SetTranslate(Button.TextProperty, "ClickedOneTime", count);
+            else
+                CounterBtn.SetTranslate(Button.TextProperty, "ClickedManyTimes", count);
+
+            SemanticScreenReader.Announce(CounterBtn.Text);
+        }
 
         private void OnToggleLanguage(object sender, EventArgs e)
         {

--- a/LocalizationResourceManager.Maui.Sample/MainPage.xaml.cs
+++ b/LocalizationResourceManager.Maui.Sample/MainPage.xaml.cs
@@ -3,10 +3,15 @@ using System.Globalization;
 
 namespace LocalizationResourceManager.Maui.Sample
 {
+    public record class Option
+    {
+        public string Localization { get; set; } = string.Empty;
+    }
     public partial class MainPage : ContentPage
     {
         private int count = 0;
         private readonly ILocalizationResourceManager resourceManager;
+        public List<Option> MyStrings { get; } = new () { new Option { Localization = "ClickMe" }, new Option { Localization = "ClickedOneTime" }, new Option { Localization = "ClickedManyTimes" } };
 
         public LocalizedString HelloWorld { get; }
         public LocalizedString CurrentCulture { get; }

--- a/LocalizationResourceManager.Maui/TranslateExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtension.cs
@@ -1,41 +1,166 @@
-﻿namespace LocalizationResourceManager.Maui;
+﻿using System.Collections.ObjectModel;
+using System.Globalization;
+
+namespace LocalizationResourceManager.Maui;
 
 /// <summary>
 /// Markup extension (XAML) for handling and updating localized string by tracking current culture from current localization resource manager.
 /// </summary>
+/// <example>
+/// <Button x:Name="CounterBtn" Text="{localization:Translate ClickMe}" />
+/// <Button x:Name="CounterBtnOne" Text="{localization:Translate ClickedOneTime, X0={Binding Count}}" />
+/// <Button x:Name="CounterBtnMany" Text="{localization:Translate ClickedManyTimes, X0={Binding Count}}" />
+/// </example>
 [ContentProperty(nameof(Text))]
-public class TranslateExtension : IMarkupExtension<BindingBase>
+public class TranslateExtension : BindableObject, IMarkupExtension<BindingBase>
 {
-    private string text = string.Empty;
-
-    public string Text
+    /// <summary>
+    /// A localize string or a binding to a localize string.
+    /// </summary>
+    public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(object), typeof(TranslateExtension), string.Empty);
+    public object Text
     {
-        get => text;
-        set => text = LocalizationResourceManager.Current.IsNameWithDotsSupported
-            ? value.Replace(".", LocalizationResourceManager.Current.DotSubstitution)
-            : value;
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
     }
 
-    public string? StringFormat { get; set; }
+    /// <summary>
+    /// Value or binding that will be used as argument {0} in the localized string
+    /// </summary>
+    public object? X0 { get; set; } = null;
+
+    /// <summary>
+    /// Value or binding that will be used as argument {1} in the localized string
+    /// </summary>
+    public object? X1 { get; set; } = null;
+
+    /// <summary>
+    /// Value or binding that will be used as argument {2} in the localized string
+    /// </summary>
+    public object? X2 { get; set; } = null;
+
+    /// <summary>
+    /// Value or binding that will be used as argument {3} in the localized string
+    /// </summary>
+    public object? X3 { get; set; } = null;
+
+    /// <summary>
+    /// Value or binding that will be used as argument {4} in the localized string
+    /// </summary>
+    public object? X4 { get; set; } = null;
+
+    /// <summary>
+    /// Value or binding that will be used as argument {5} in the localized string
+    /// </summary>
+    public object? X5 { get; set; } = null;
+
+    /// <summary>
+    /// Value or binding that will be used as argument {6} in the localized string
+    /// </summary>
+    public object? X6 { get; set; } = null;
+
+    /// <summary>
+    /// Value or binding that will be used as argument {7} in the localized string
+    /// </summary>
+    public object? X7 { get; set; } = null;
+
+    /// <summary>
+    /// Value or binding that will be used as argument {8} in the localized string
+    /// </summary>
+    public object? X8 { get; set; } = null;
+
+    /// <summary>
+    /// Value or binding that will be used as argument {9} in the localized string
+    /// </summary>
+    public object? X9 { get; set; } = null;
 
     object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) => ProvideValue(serviceProvider);
 
+    /// <summary>
+    /// A binding to a localized string resource.
+    /// </summary>
+    /// <param name="serviceProvider"></param>
+    /// <returns>A binding to a localized string resource.</returns>
     public BindingBase ProvideValue(IServiceProvider serviceProvider)
     {
-        #region Required work-around to prevent linker from removing the implementation
-
-        if (DateTime.Now.Ticks < 0)
-            _ = LocalizationResourceManager.Current[Text];
-
-        #endregion Required work-around to prevent linker from removing the implementation
-
-        var binding = new Binding
+        object?[] values = { X0, X1, X2, X3, X4, X5, X6, X7, X8, X9 };
+        int maxIndex = -1;
+        for (int i = 0; i < values.Length; i++)
         {
-            Mode = BindingMode.OneWay,
-            Path = $"[{Text}]",
-            Source = LocalizationResourceManager.Current,
-            StringFormat = StringFormat
+            if (values[i] is not null)
+            {
+                maxIndex = i;
+            }
+        }
+
+        return NewBinding(Text, values.Take(maxIndex + 1).ToArray());
+    }
+
+    /// <summary>
+    /// Creates a BindingBase to a localize string with optional arguments.
+    /// Used by SetTranslate extension method.
+    /// </summary>
+    /// <example>
+    /// CounterBtn.SetBinding(Button.TextProperty, new TranslateExtension().NewBinding("ClickMe"));
+    /// CounterBtnOne.SetBinding(Button.TextProperty, new TranslateExtension().NewBinding("ClickedOneTime", count));
+    /// CounterBtnMany.SetBinding(Button.TextProperty, new TranslateExtension().NewBinding("ClickedManyTimes", count));
+    /// </example>
+    /// <param name="text">A localize string resource or a binding to a localize string resource</param>
+    /// <param name="arguments">An array of arguments or binding to arguments</param>
+    /// <returns></returns>
+    public BindingBase NewBinding(object text, params object?[] arguments)
+    {
+        Collection<BindingBase> bindings = new Collection<BindingBase>
+        {
+            (text is BindingBase textBinding) ? textBinding : new Binding(".", source: text)
         };
-        return binding;
+
+        bindings.Add(new Binding("CurrentCulture", BindingMode.OneWay, null, null, null, LocalizationResourceManager.Current));
+
+        foreach (var value in arguments)
+        {
+            bindings.Add((value is BindingBase binding) ? binding : new Binding(".", source: value));
+        }
+
+        return new MultiBinding()
+        {
+            Bindings = bindings,
+            Converter = new TranslateExtensionConverter()
+        };
+    }
+
+
+    internal sealed class TranslateExtensionConverter : IMultiValueConverter
+    {
+        public object? Convert(object?[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values is not null && values[0] is string text && values[1] is CultureInfo c)
+            {
+                if (LocalizationResourceManager.Current.IsNameWithDotsSupported)
+                {
+                    text = text.Replace(".", LocalizationResourceManager.Current.DotSubstitution);
+                }
+
+                object obj = LocalizationResourceManager.Current.GetValue(text);
+                if (obj is null)
+                {
+                    return null;
+                }
+
+                if (values.Length > 2 && obj is string format)
+                {
+                    obj = string.Format(format, values.Skip(2).ToArray());
+                }
+
+                return $"{obj}";
+            }
+
+            return null;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/LocalizationResourceManager.Maui/TranslateExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtension.cs
@@ -145,38 +145,4 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
             Converter = new TranslateExtensionConverter()
         };
     }
-
-    internal sealed class TranslateExtensionConverter : IMultiValueConverter
-    {
-        public object? Convert(object?[] values, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (values is not null && values[0] is string text && values[1] is CultureInfo c)
-            {
-                if (LocalizationResourceManager.Current.IsNameWithDotsSupported)
-                {
-                    text = text.Replace(".", LocalizationResourceManager.Current.DotSubstitution);
-                }
-
-                object obj = LocalizationResourceManager.Current.GetValue(text);
-                if (obj is null)
-                {
-                    return null;
-                }
-
-                if (values.Length > 2 && obj is string format)
-                {
-                    obj = string.Format(format, values.Skip(2).ToArray());
-                }
-
-                return $"{obj}";
-            }
-
-            return null;
-        }
-
-        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
 }

--- a/LocalizationResourceManager.Maui/TranslateExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtension.cs
@@ -83,6 +83,11 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
     /// <returns>A binding to a localized string resource.</returns>
     public BindingBase ProvideValue(IServiceProvider serviceProvider)
     {
+        #region Required work-around to prevent linker from removing the implementation
+        if (DateTime.Now.Ticks < 0 && Text is string text)
+            _ = LocalizationResourceManager.Current[text];
+        #endregion Required work-around to prevent linker from removing the implementation
+
         object?[] values = { X0, X1, X2, X3, X4, X5, X6, X7, X8, X9 };
         int maxIndex = -1;
         for (int i = 0; i < values.Length; i++)

--- a/LocalizationResourceManager.Maui/TranslateExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtension.cs
@@ -17,12 +17,7 @@ public class TranslateExtension : BindableObject, IMarkupExtension<BindingBase>
     /// <summary>
     /// A localize string or a binding to a localize string.
     /// </summary>
-    public static readonly BindableProperty TextProperty = BindableProperty.Create("Text", typeof(object), typeof(TranslateExtension), string.Empty);
-    public object Text
-    {
-        get => GetValue(TextProperty);
-        set => SetValue(TextProperty, value);
-    }
+    public object? Text { get; set; } = null;
 
     /// <summary>
     /// Value or binding that will be used as argument {0} in the localized string

--- a/LocalizationResourceManager.Maui/TranslateExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtension.cs
@@ -17,7 +17,7 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
     /// <summary>
     /// A localize string or a binding to a localize string.
     /// </summary>
-    public object? Text { get; set; } = null;
+    public object? Text { get; set; } = string.Empty;
 
     /// <summary>
     /// A string format to apply to the text string.
@@ -88,9 +88,12 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
             _ = LocalizationResourceManager.Current[text];
         #endregion Required work-around to prevent linker from removing the implementation
 
-        object?[] values = { X0, X1, X2, X3, X4, X5, X6, X7, X8, X9 };
-        int maxIndex = values.Select(v => v is not null).ToList<bool>().LastIndexOf(true);
-        return NewBinding(Text, StringFormat, values.Take(maxIndex + 1).ToArray());
+        List<object?> values = new List<object?>() { X0, X1, X2, X3, X4, X5, X6, X7, X8, X9 };
+        while (values.Count > 0 && values[values.Count - 1] is null)
+        {
+            values.RemoveAt(values.Count - 1);
+        }
+        return NewBinding(Text, StringFormat, values.ToArray());
     }
 
     /// <summary>

--- a/LocalizationResourceManager.Maui/TranslateExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtension.cs
@@ -98,14 +98,15 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
     /// Used by SetTranslate extension method.
     /// </summary>
     /// <example>
-    /// CounterBtn.SetBinding(Button.TextProperty, new TranslateExtension().NewBinding("ClickMe"));
-    /// CounterBtnOne.SetBinding(Button.TextProperty, new TranslateExtension().NewBinding("ClickedOneTime", count));
-    /// CounterBtnMany.SetBinding(Button.TextProperty, new TranslateExtension().NewBinding("ClickedManyTimes", count));
+    /// CounterBtn.SetBinding(Button.TextProperty, TranslateExtension.NewBinding("ClickMe"));
+    /// CounterBtnOne.SetBinding(Button.TextProperty, TranslateExtension.NewBinding("ClickedOneTime", null, count));
+    /// CounterBtnMany.SetBinding(Button.TextProperty, TranslateExtension.NewBinding("ClickedManyTimes", null, count));
     /// </example>
     /// <param name="text">A localize string resource or a binding to a localize string resource</param>
+    /// <param name="stringFormat">A string format to apply to the text string</param>
     /// <param name="arguments">An array of arguments or binding to arguments</param>
     /// <returns></returns>
-    public static BindingBase NewBinding(object? text, string? stringFormat, params object?[] arguments)
+    public static BindingBase NewBinding(object? text, string? stringFormat = null, params object?[] arguments)
     {
         if (text is string value && arguments.Length == 0)
         {

--- a/LocalizationResourceManager.Maui/TranslateExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtension.cs
@@ -93,7 +93,7 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
             }
         }
 
-        return NewBinding(Text, values.Take(maxIndex + 1).ToArray());
+        return NewBinding(Text, StringFormat, values.Take(maxIndex + 1).ToArray());
     }
 
     /// <summary>
@@ -108,7 +108,7 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
     /// <param name="text">A localize string resource or a binding to a localize string resource</param>
     /// <param name="arguments">An array of arguments or binding to arguments</param>
     /// <returns></returns>
-    public BindingBase NewBinding(object? text, params object?[] arguments)
+    public static BindingBase NewBinding(object? text, string? stringFormat, params object?[] arguments)
     {
         if (text is string value && arguments.Length == 0)
         {
@@ -122,7 +122,7 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
                 Mode = BindingMode.OneWay,
                 Path = $"[{value}]",
                 Source = LocalizationResourceManager.Current,
-                StringFormat = StringFormat
+                StringFormat = stringFormat
             };
             return binding;
         }
@@ -143,11 +143,10 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
         {
             Mode = BindingMode.OneWay,
             Bindings = bindings,
-            StringFormat = StringFormat,
+            StringFormat = stringFormat,
             Converter = new TranslateExtensionConverter()
         };
     }
-
 
     internal sealed class TranslateExtensionConverter : IMultiValueConverter
     {

--- a/LocalizationResourceManager.Maui/TranslateExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtension.cs
@@ -130,10 +130,9 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
 
         Collection<BindingBase> bindings = new Collection<BindingBase>
         {
-            (text is BindingBase textBinding) ? textBinding : new Binding(".", source: text)
+            (text is BindingBase textBinding) ? textBinding : new Binding(".", source: text),
+            new Binding("CurrentCulture", source: LocalizationResourceManager.Current)
         };
-
-        bindings.Add(new Binding("CurrentCulture", BindingMode.OneWay, null, null, null, LocalizationResourceManager.Current));
 
         foreach (var arg in arguments)
         {

--- a/LocalizationResourceManager.Maui/TranslateExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtension.cs
@@ -89,15 +89,7 @@ public class TranslateExtension : IMarkupExtension<BindingBase>
         #endregion Required work-around to prevent linker from removing the implementation
 
         object?[] values = { X0, X1, X2, X3, X4, X5, X6, X7, X8, X9 };
-        int maxIndex = -1;
-        for (int i = 0; i < values.Length; i++)
-        {
-            if (values[i] is not null)
-            {
-                maxIndex = i;
-            }
-        }
-
+        int maxIndex = values.Select(v => v is not null).ToList<bool>().LastIndexOf(true);
         return NewBinding(Text, StringFormat, values.Take(maxIndex + 1).ToArray());
     }
 

--- a/LocalizationResourceManager.Maui/TranslateExtension.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtension.cs
@@ -12,7 +12,7 @@ namespace LocalizationResourceManager.Maui;
 /// <Button x:Name="CounterBtnMany" Text="{localization:Translate ClickedManyTimes, X0={Binding Count}}" />
 /// </example>
 [ContentProperty(nameof(Text))]
-public class TranslateExtension : BindableObject, IMarkupExtension<BindingBase>
+public class TranslateExtension : IMarkupExtension<BindingBase>
 {
     /// <summary>
     /// A localize string or a binding to a localize string.
@@ -103,7 +103,7 @@ public class TranslateExtension : BindableObject, IMarkupExtension<BindingBase>
     /// <param name="text">A localize string resource or a binding to a localize string resource</param>
     /// <param name="arguments">An array of arguments or binding to arguments</param>
     /// <returns></returns>
-    public BindingBase NewBinding(object text, params object?[] arguments)
+    public BindingBase NewBinding(object? text, params object?[] arguments)
     {
         Collection<BindingBase> bindings = new Collection<BindingBase>
         {

--- a/LocalizationResourceManager.Maui/TranslateExtensionConverter.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtensionConverter.cs
@@ -1,0 +1,37 @@
+﻿using System.Globalization;
+
+namespace LocalizationResourceManager.Maui;
+
+internal sealed class TranslateExtensionConverter : IMultiValueConverter
+{
+    public object? Convert(object?[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values is not null && values[0] is string text && values[1] is CultureInfo c)
+        {
+            if (LocalizationResourceManager.Current.IsNameWithDotsSupported)
+            {
+                text = text.Replace(".", LocalizationResourceManager.Current.DotSubstitution);
+            }
+
+            object obj = LocalizationResourceManager.Current.GetValue(text);
+            if (obj is null)
+            {
+                return null;
+            }
+
+            if (values.Length > 2 && obj is string format)
+            {
+                obj = string.Format(format, values.Skip(2).ToArray());
+            }
+
+            return $"{obj}";
+        }
+
+        return null;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/LocalizationResourceManager.Maui/TranslateExtensionMethod.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtensionMethod.cs
@@ -23,6 +23,6 @@ public static class TranslateExtensionMethod
     /// // count as a binding
     /// CounterBtn.SetTranslate(Button.TextProperty, "ClickedManyTimes", new Binding(nameof(Count), source: this));
     /// </example>
-    public static void SetTranslate(this BindableObject bindable, BindableProperty targetProperty, object text, params object[] args)
-        => bindable.SetBinding(targetProperty, new TranslateExtension().NewBinding(text, args));
+    public static void SetTranslate(this BindableObject bindable, BindableProperty targetProperty, object? text, params object?[] args)
+        => bindable.SetBinding(targetProperty, TranslateExtension.NewBinding(text, null, args));
 }

--- a/LocalizationResourceManager.Maui/TranslateExtensionMethod.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtensionMethod.cs
@@ -1,0 +1,21 @@
+﻿namespace LocalizationResourceManager.Maui;
+
+/// <summary>
+/// Provides the SetTranslate extension method.
+/// </summary>
+public static class TranslateExtensionMethod
+{
+    /// <summary>
+    /// .NET MAUI SetTranslate extension method that enable VisualElement objects to respond to localization changes.
+    /// </summary>
+    /// <param name="bindable">The BindableObject</param>
+    /// <param name="targetProperty">The BindableProperty on which to set a localized string</param>
+    /// <param name="text">A localized string or a binding to a localize string</param>
+    /// <param name="args">A collection of arguments or a binding to arguments</param>
+    /// <example>
+    /// CounterBtn.SetTranslate(Button.TextProperty, "ClickedManyTimes", count);
+    /// CounterBtn2.SetTranslate(Button.TextProperty, "ClickedManyTimes", new Binding(nameof(Count), source: this));
+    /// </example>
+    public static void SetTranslate(this BindableObject bindable, BindableProperty targetProperty, object text, params object[] args)
+        => bindable.SetBinding(targetProperty, new TranslateExtension().NewBinding(text, args));
+}

--- a/LocalizationResourceManager.Maui/TranslateExtensionMethod.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtensionMethod.cs
@@ -13,14 +13,14 @@ public static class TranslateExtensionMethod
     /// <param name="text">A localized string or a binding to a localize string</param>
     /// <param name="args">A collection of arguments or a binding to arguments</param>
     /// <example>
-    /// // count as constant arguments
+    /// // count as a scalar constant
     /// if (count == 0)
     ///     CounterBtn.SetTranslate(Button.TextProperty, "ClickMe");
     /// else if (count == 1)
     ///     CounterBtn.SetTranslate(Button.TextProperty, "ClickedOneTime", count);
     /// else
     ///     CounterBtn.SetTranslate(Button.TextProperty, "ClickedManyTimes", count);
-    /// // count as a binding
+    /// // count passed as a binding
     /// CounterBtn.SetTranslate(Button.TextProperty, "ClickedManyTimes", new Binding(nameof(Count), source: this));
     /// </example>
     public static void SetTranslate(this BindableObject bindable, BindableProperty targetProperty, object? text, params object?[] args)

--- a/LocalizationResourceManager.Maui/TranslateExtensionMethod.cs
+++ b/LocalizationResourceManager.Maui/TranslateExtensionMethod.cs
@@ -13,8 +13,15 @@ public static class TranslateExtensionMethod
     /// <param name="text">A localized string or a binding to a localize string</param>
     /// <param name="args">A collection of arguments or a binding to arguments</param>
     /// <example>
-    /// CounterBtn.SetTranslate(Button.TextProperty, "ClickedManyTimes", count);
-    /// CounterBtn2.SetTranslate(Button.TextProperty, "ClickedManyTimes", new Binding(nameof(Count), source: this));
+    /// // count as constant arguments
+    /// if (count == 0)
+    ///     CounterBtn.SetTranslate(Button.TextProperty, "ClickMe");
+    /// else if (count == 1)
+    ///     CounterBtn.SetTranslate(Button.TextProperty, "ClickedOneTime", count);
+    /// else
+    ///     CounterBtn.SetTranslate(Button.TextProperty, "ClickedManyTimes", count);
+    /// // count as a binding
+    /// CounterBtn.SetTranslate(Button.TextProperty, "ClickedManyTimes", new Binding(nameof(Count), source: this));
     /// </example>
     public static void SetTranslate(this BindableObject bindable, BindableProperty targetProperty, object text, params object[] args)
         => bindable.SetBinding(targetProperty, new TranslateExtension().NewBinding(text, args));


### PR DESCRIPTION
Summary:
 - Implement Translate new Text, X0, X1, ... X9 bindable properties #34 
 - Implement SetTranslate extension method #35 

Description of files changed:
 - MainPage.xaml
   - Add ContentPage.Title so that we can see dynamic title changes
   - Revert CounterBtn to use Translate instead of TranslateBinding (closer to stock .NET MAUI program)
 - MainPage.xaml.cs
   - Revert MainPage.xaml.cs so it's closer to stock .NET MAUI program
   - Demonstrate new SetTranslate extension method
 - TranslateExtension.cs
   - Rewrite to use a MultiBinding instead of Building to support Text and variable parameters expressed in X0..X9
 - TranslateExtensionConverter.cs
   - An internal class for reducing the MultiBinding created by TranslateExtension to a localized string
 - TranslateExtensionMethod.cs
   - New static class with static method implementing SetTranslate extension method
